### PR TITLE
Remove IUpdateGroupDescribed interface

### DIFF
--- a/Assets/UGF.Module.Update.Runtime.Tests/TestUpdateModule.cs
+++ b/Assets/UGF.Module.Update.Runtime.Tests/TestUpdateModule.cs
@@ -44,7 +44,7 @@ namespace UGF.Module.Update.Runtime.Tests
             application.Initialize();
 
             var module = application.GetModule<IUpdateModule>();
-            var group = module.GetGroup<IUpdateGroupDescribed>("4614ceca8914e5b4d8326f86aded3229");
+            var group = module.GetGroup<IUpdateGroup>("4614ceca8914e5b4d8326f86aded3229");
 
             Assert.NotNull(group);
             Assert.AreEqual("Group", group.Name);

--- a/Packages/UGF.Module.Update/Runtime/IUpdateGroupBuilder.cs
+++ b/Packages/UGF.Module.Update/Runtime/IUpdateGroupBuilder.cs
@@ -1,8 +1,9 @@
 ﻿using UGF.Builder.Runtime;
+using UGF.Update.Runtime;
 
 namespace UGF.Module.Update.Runtime
 {
-    public interface IUpdateGroupBuilder : IBuilder<IUpdateGroupDescribed>
+    public interface IUpdateGroupBuilder : IBuilder<IUpdateGroup>
     {
     }
 }

--- a/Packages/UGF.Module.Update/Runtime/IUpdateGroupDescribed.cs
+++ b/Packages/UGF.Module.Update/Runtime/IUpdateGroupDescribed.cs
@@ -1,9 +1,0 @@
-﻿using UGF.Description.Runtime;
-using UGF.Update.Runtime;
-
-namespace UGF.Module.Update.Runtime
-{
-    public interface IUpdateGroupDescribed : IUpdateGroup, IDescribed<IUpdateGroupDescription>
-    {
-    }
-}

--- a/Packages/UGF.Module.Update/Runtime/IUpdateGroupDescribed.cs.meta
+++ b/Packages/UGF.Module.Update/Runtime/IUpdateGroupDescribed.cs.meta
@@ -1,3 +1,0 @@
-﻿fileFormatVersion: 2
-guid: 7b676ad9d6a244e3abd91ddf6338ef55
-timeCreated: 1606845176

--- a/Packages/UGF.Module.Update/Runtime/IUpdateModule.cs
+++ b/Packages/UGF.Module.Update/Runtime/IUpdateModule.cs
@@ -9,19 +9,19 @@ namespace UGF.Module.Update.Runtime
         new IUpdateModuleDescription Description { get; }
         IUpdateProvider Provider { get; }
         IReadOnlyDictionary<string, IUpdateSystemDescription> Systems { get; }
-        IReadOnlyDictionary<string, IUpdateGroupDescribed> Groups { get; }
+        IReadOnlyDictionary<string, IUpdateGroup> Groups { get; }
 
         void AddSystem(string id, IUpdateSystemDescription description);
         bool RemoveSystem(string id);
-        void AddGroup(string id, IUpdateGroupDescribed group);
+        void AddGroup(string id, IUpdateGroup group);
         bool RemoveGroup(string id);
         T GetSystem<T>(string id) where T : IUpdateSystemDescription;
         IUpdateSystemDescription GetSystem(string id);
         bool TryGetSystem<T>(string id, out T description) where T : class, IUpdateSystemDescription;
         bool TryGetSystem(string id, out IUpdateSystemDescription description);
-        T GetGroup<T>(string id) where T : class, IUpdateGroupDescribed;
-        IUpdateGroupDescribed GetGroup(string id);
-        bool TryGetGroup<T>(string id, out T group) where T : class, IUpdateGroupDescribed;
-        bool TryGetGroup(string id, out IUpdateGroupDescribed group);
+        T GetGroup<T>(string id) where T : class, IUpdateGroup;
+        IUpdateGroup GetGroup(string id);
+        bool TryGetGroup<T>(string id, out T group) where T : class, IUpdateGroup;
+        bool TryGetGroup(string id, out IUpdateGroup group);
     }
 }

--- a/Packages/UGF.Module.Update/Runtime/UpdateGroupAssetBase.cs
+++ b/Packages/UGF.Module.Update/Runtime/UpdateGroupAssetBase.cs
@@ -1,18 +1,40 @@
-﻿using UGF.Description.Runtime;
+﻿using System;
+using UGF.Builder.Runtime;
+using UGF.Description.Runtime;
 using UGF.Update.Runtime;
 
 namespace UGF.Module.Update.Runtime
 {
-    public abstract class UpdateGroupAssetBase : DescribedWithDescriptionBuilderAsset<IUpdateGroupDescribed, IUpdateGroupDescription>, IUpdateGroupBuilder
+    public abstract class UpdateGroupAssetBase : BuilderAsset<IUpdateGroup>, IUpdateGroupBuilder, IDescriptionBuilder
     {
-        protected override IUpdateGroupDescribed OnBuild(IUpdateGroupDescription description)
+        protected override IUpdateGroup OnBuild()
+        {
+            IUpdateGroupDescription description = OnBuildDescription();
+
+            if (description == null) throw new ArgumentNullException(nameof(description), "Description can not be null.");
+
+            return OnBuild(description);
+        }
+
+        protected virtual IUpdateGroup OnBuild(IUpdateGroupDescription description)
         {
             IUpdateCollection collection = OnBuildCollection();
 
             return OnBuild(collection, description);
         }
 
+        protected abstract IUpdateGroupDescription OnBuildDescription();
         protected abstract IUpdateCollection OnBuildCollection();
-        protected abstract IUpdateGroupDescribed OnBuild(IUpdateCollection collection, IUpdateGroupDescription description);
+        protected abstract IUpdateGroup OnBuild(IUpdateCollection collection, IUpdateGroupDescription description);
+
+        T IBuilder<IDescription>.Build<T>()
+        {
+            return (T)OnBuildDescription();
+        }
+
+        IDescription IBuilder<IDescription>.Build()
+        {
+            return OnBuildDescription();
+        }
     }
 }

--- a/Packages/UGF.Module.Update/Runtime/UpdateGroupAsset`1.cs
+++ b/Packages/UGF.Module.Update/Runtime/UpdateGroupAsset`1.cs
@@ -23,12 +23,12 @@ namespace UGF.Module.Update.Runtime
             return new UpdateGroupDescription(type);
         }
 
-        protected override IUpdateGroupDescribed OnBuild(IUpdateCollection collection, IUpdateGroupDescription description)
+        protected override IUpdateGroup OnBuild(IUpdateCollection collection, IUpdateGroupDescription description)
         {
             return OnBuild((IUpdateCollection<TItem>)collection, (TDescription)description);
         }
 
-        protected virtual IUpdateGroupDescribed OnBuild(IUpdateCollection<TItem> collection, TDescription description)
+        protected virtual IUpdateGroup OnBuild(IUpdateCollection<TItem> collection, TDescription description)
         {
             return new UpdateGroupDescribed<TItem, TDescription>(m_name, collection, description);
         }

--- a/Packages/UGF.Module.Update/Runtime/UpdateGroupDescribed.cs
+++ b/Packages/UGF.Module.Update/Runtime/UpdateGroupDescribed.cs
@@ -4,7 +4,7 @@ using UGF.Update.Runtime;
 
 namespace UGF.Module.Update.Runtime
 {
-    public class UpdateGroupDescribed<TItem, TDescription> : UpdateGroup<TItem>, IUpdateGroupDescribed
+    public class UpdateGroupDescribed<TItem, TDescription> : UpdateGroup<TItem>, IDescribed<IUpdateGroupDescription>
         where TItem : class
         where TDescription : class, IUpdateGroupDescription
     {


### PR DESCRIPTION
- Remove `IUpdateGroupDescribed` interface.
- Change `IUpdateModule`, `UpdateGroupAssetBase` and `UpdateGroupDescribed<TItem, TDescription>` classes to work with `IUpdateGroup` directly.