### PR TITLE
Rework to use providers for systems and groups in module

### DIFF
--- a/Assets/UGF.Module.Update.Runtime.Tests/TestUpdateModule.cs
+++ b/Assets/UGF.Module.Update.Runtime.Tests/TestUpdateModule.cs
@@ -44,7 +44,7 @@ namespace UGF.Module.Update.Runtime.Tests
             application.Initialize();
 
             var module = application.GetModule<IUpdateModule>();
-            var group = module.GetGroup<IUpdateGroup>("4614ceca8914e5b4d8326f86aded3229");
+            var group = module.Groups.Get<IUpdateGroup>("4614ceca8914e5b4d8326f86aded3229");
 
             Assert.NotNull(group);
             Assert.AreEqual("Group", group.Name);

--- a/Assets/UGF.Module.Update.Runtime.Tests/TestUpdateModule.cs
+++ b/Assets/UGF.Module.Update.Runtime.Tests/TestUpdateModule.cs
@@ -29,11 +29,11 @@ namespace UGF.Module.Update.Runtime.Tests
             var module = application.GetModule<IUpdateModule>();
 
             Assert.NotNull(module);
-            Assert.AreEqual(module.Provider.Groups.Count, 1);
+            Assert.AreEqual(1, module.Provider.Groups.Count);
 
             application.Uninitialize();
 
-            Assert.AreEqual(module.Provider.Groups.Count, 0);
+            Assert.AreEqual(0, module.Provider.Groups.Count);
         }
 
         [UnityTest]

--- a/Assets/UGF.Module.Update.Runtime.Tests/UGF.Module.Update.Runtime.Tests.asmdef
+++ b/Assets/UGF.Module.Update.Runtime.Tests/UGF.Module.Update.Runtime.Tests.asmdef
@@ -7,7 +7,8 @@
         "GUID:a4312e46e9f64bb4aa011ac96ffd2a61",
         "GUID:d067af32d09350a4bb33960432735e4d",
         "GUID:27619889b8ba8c24980f49ee34dbb44a",
-        "GUID:3ad3a680cb737c6428dc532d551e7bb7"
+        "GUID:3ad3a680cb737c6428dc532d551e7bb7",
+        "GUID:16fde9420ef50f34db61e711e19381dd"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Packages/UGF.Module.Update/Runtime/IUpdateModule.cs
+++ b/Packages/UGF.Module.Update/Runtime/IUpdateModule.cs
@@ -1,5 +1,5 @@
-using System.Collections.Generic;
 using UGF.Application.Runtime;
+using UGF.RuntimeTools.Runtime.Providers;
 using UGF.Update.Runtime;
 
 namespace UGF.Module.Update.Runtime
@@ -8,20 +8,7 @@ namespace UGF.Module.Update.Runtime
     {
         new IUpdateModuleDescription Description { get; }
         IUpdateProvider Provider { get; }
-        IReadOnlyDictionary<string, IUpdateSystemDescription> Systems { get; }
-        IReadOnlyDictionary<string, IUpdateGroup> Groups { get; }
-
-        void AddSystem(string id, IUpdateSystemDescription description);
-        bool RemoveSystem(string id);
-        void AddGroup(string id, IUpdateGroup group);
-        bool RemoveGroup(string id);
-        T GetSystem<T>(string id) where T : IUpdateSystemDescription;
-        IUpdateSystemDescription GetSystem(string id);
-        bool TryGetSystem<T>(string id, out T description) where T : class, IUpdateSystemDescription;
-        bool TryGetSystem(string id, out IUpdateSystemDescription description);
-        T GetGroup<T>(string id) where T : class, IUpdateGroup;
-        IUpdateGroup GetGroup(string id);
-        bool TryGetGroup<T>(string id, out T group) where T : class, IUpdateGroup;
-        bool TryGetGroup(string id, out IUpdateGroup group);
+        IProvider<string, IUpdateSystemDescription> Systems { get; }
+        IProvider<string, IUpdateGroup> Groups { get; }
     }
 }

--- a/Packages/UGF.Module.Update/Runtime/UGF.Module.Update.Runtime.asmdef
+++ b/Packages/UGF.Module.Update/Runtime/UGF.Module.Update.Runtime.asmdef
@@ -8,7 +8,8 @@
         "GUID:088d00b6871540e44bce58af1a3f0f17",
         "GUID:6c7389a7d4bbed54e96eb1e71a69798e",
         "GUID:3ad3a680cb737c6428dc532d551e7bb7",
-        "GUID:6ca210c6fc8b79d4292f3cdb1061c73e"
+        "GUID:6ca210c6fc8b79d4292f3cdb1061c73e",
+        "GUID:16fde9420ef50f34db61e711e19381dd"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Packages/UGF.Module.Update/Runtime/UpdateGroupProvider.cs
+++ b/Packages/UGF.Module.Update/Runtime/UpdateGroupProvider.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using UGF.Description.Runtime;
+using UGF.Logs.Runtime;
+using UGF.RuntimeTools.Runtime.Providers;
+using UGF.Update.Runtime;
+
+namespace UGF.Module.Update.Runtime
+{
+    public class UpdateGroupProvider : Provider<string, IUpdateGroup>
+    {
+        public IUpdateProvider UpdateProvider { get; }
+
+        public UpdateGroupProvider(IUpdateProvider updateProvider) : this(updateProvider, EqualityComparer<string>.Default)
+        {
+        }
+
+        public UpdateGroupProvider(IUpdateProvider updateProvider, IEqualityComparer<string> comparer) : base(comparer)
+        {
+            UpdateProvider = updateProvider ?? throw new ArgumentNullException(nameof(updateProvider));
+        }
+
+        protected override void OnAdd(string id, IUpdateGroup entry)
+        {
+            if (!(entry is IDescribed<IUpdateGroupDescription> described)) throw new ArgumentException("Entry must be of 'IDescribed<IUpdateGroupDescription>' type.", nameof(entry));
+
+            UpdateProvider.Add(described.Description.SystemType, entry);
+
+            base.OnAdd(id, entry);
+
+            Log.Debug("Add update group", new
+            {
+                id,
+                entry.Name,
+                described.Description.SystemType
+            });
+        }
+
+        protected override bool OnRemove(string id, IUpdateGroup entry)
+        {
+            UpdateProvider.Remove(entry);
+
+            Log.Debug("Remove update group", new
+            {
+                id,
+                entry.Name
+            });
+
+            return base.OnRemove(id, entry);
+        }
+    }
+}

--- a/Packages/UGF.Module.Update/Runtime/UpdateGroupProvider.cs
+++ b/Packages/UGF.Module.Update/Runtime/UpdateGroupProvider.cs
@@ -48,5 +48,15 @@ namespace UGF.Module.Update.Runtime
 
             return base.OnRemove(id, entry);
         }
+
+        protected override void OnClear()
+        {
+            foreach (KeyValuePair<string, IUpdateGroup> pair in this)
+            {
+                UpdateProvider.Remove(pair.Key);
+            }
+
+            base.OnClear();
+        }
     }
 }

--- a/Packages/UGF.Module.Update/Runtime/UpdateGroupProvider.cs
+++ b/Packages/UGF.Module.Update/Runtime/UpdateGroupProvider.cs
@@ -53,7 +53,7 @@ namespace UGF.Module.Update.Runtime
         {
             foreach (KeyValuePair<string, IUpdateGroup> pair in this)
             {
-                UpdateProvider.Remove(pair.Key);
+                UpdateProvider.Remove(pair.Value);
             }
 
             base.OnClear();

--- a/Packages/UGF.Module.Update/Runtime/UpdateGroupProvider.cs.meta
+++ b/Packages/UGF.Module.Update/Runtime/UpdateGroupProvider.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a1070e31d01f4a88ac2d7c63313e1095
+timeCreated: 1614710572

--- a/Packages/UGF.Module.Update/Runtime/UpdateSystemDescriptionProvider.cs
+++ b/Packages/UGF.Module.Update/Runtime/UpdateSystemDescriptionProvider.cs
@@ -48,5 +48,15 @@ namespace UGF.Module.Update.Runtime
 
             return base.OnRemove(id, entry);
         }
+
+        protected override void OnClear()
+        {
+            foreach (KeyValuePair<string, IUpdateSystemDescription> pair in this)
+            {
+                UpdateProvider.UpdateLoop.Remove(pair.Value.SystemType);
+            }
+
+            base.OnClear();
+        }
     }
 }

--- a/Packages/UGF.Module.Update/Runtime/UpdateSystemDescriptionProvider.cs
+++ b/Packages/UGF.Module.Update/Runtime/UpdateSystemDescriptionProvider.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using UGF.Logs.Runtime;
+using UGF.RuntimeTools.Runtime.Providers;
+using UGF.Update.Runtime;
+
+namespace UGF.Module.Update.Runtime
+{
+    public class UpdateSystemDescriptionProvider : Provider<string, IUpdateSystemDescription>
+    {
+        public IUpdateProvider UpdateProvider { get; }
+
+        public UpdateSystemDescriptionProvider(IUpdateProvider updateProvider) : this(updateProvider, EqualityComparer<string>.Default)
+        {
+        }
+
+        public UpdateSystemDescriptionProvider(IUpdateProvider updateProvider, IEqualityComparer<string> comparer) : base(comparer)
+        {
+            UpdateProvider = updateProvider ?? throw new ArgumentNullException(nameof(updateProvider));
+        }
+
+        protected override void OnAdd(string id, IUpdateSystemDescription entry)
+        {
+            UpdateProvider.UpdateLoop.Add(entry.TargetSystemType, entry.SystemType, entry.Insertion);
+
+            base.OnAdd(id, entry);
+
+            Log.Debug("Add update system", new
+            {
+                id,
+                entry.TargetSystemType,
+                entry.SystemType,
+                entry.Insertion
+            });
+        }
+
+        protected override bool OnRemove(string id, IUpdateSystemDescription entry)
+        {
+            UpdateProvider.UpdateLoop.Remove(entry.SystemType);
+
+            Log.Debug("Remove update system", new
+            {
+                id,
+                entry.TargetSystemType,
+                entry.SystemType,
+                entry.Insertion
+            });
+
+            return base.OnRemove(id, entry);
+        }
+    }
+}

--- a/Packages/UGF.Module.Update/Runtime/UpdateSystemDescriptionProvider.cs.meta
+++ b/Packages/UGF.Module.Update/Runtime/UpdateSystemDescriptionProvider.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3ac52094ee634f3cac82aa9d45182a3c
+timeCreated: 1614710618


### PR DESCRIPTION
- Update `IUpdateModule` to replace `Systems` and `Groups` dictionaries with `IProvider` interfaces.
- Add `UpdateGroupProvider` and `UpdateSystemDescriptionProvider` provider classes with update system registration.
- Remove `Add`, `Remove`, `Get`, `TryGet` and etc manage methods from `IUpdateModule` and `UpdateModule` classes.